### PR TITLE
Add pdf embed option

### DIFF
--- a/_includes/item/pdf-embed.html
+++ b/_includes/item/pdf-embed.html
@@ -1,0 +1,10 @@
+{% comment %}
+
+    Embed PDF in so that it directly loads on the item page. 
+
+{% endcomment %}
+<div class="ratio" style="--bs-aspect-ratio: 115%;">
+    <object title="PDF file of {{ page.title }}" data="{{ page.object_location | relative_url }}" type="application/pdf" width="100%" >
+        <p>The PDF is not rendering in your browser, please use the button below to download the PDF.</p>
+    </object>
+</div>

--- a/_layouts/item/pdf.html
+++ b/_layouts/item/pdf.html
@@ -7,9 +7,9 @@ layout: item/item-page-base
     <div class="col-md-6">
         <div class="card mb-4 text-center">
             <div class="m-2">
-                <p>
-                    {% include item/item-thumb.html %}
-                </p>
+                
+                {% include item/pdf-embed.html %}
+                
             </div>
             
             <div class="my-2">


### PR DESCRIPTION
@fullerpault this PR adds the pdf-embed include and modifies your pdf item layout to use it (instead of a thumbnail). 
FYI: the embed will work on desktop browsers, but not most mobile browsers, so the fall back says to download the pdf on mobile. 